### PR TITLE
fix: import Path for serial stream type hints

### DIFF
--- a/cam_slicer/sender/serial_stream.py
+++ b/cam_slicer/sender/serial_stream.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 try:
     import serial
 except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency


### PR DESCRIPTION
## Summary
- import Path so serial_stream's type hints compile on Python 3.12

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile cam_slicer/sender/serial_stream.py`
- `PYTHONDONTWRITEBYTECODE=1 pytest` *(fails: cannot import name 'load_plugins', IndentationError in digital_twin.py, missing httpx, libGL.so.1, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ea97df608333967e66231bc2ae82