### PR TITLE
refactor: simplify digital twin and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ from cam_slicer.logging_config import export_critical_logs
 report = export_critical_logs(email="ops@example.com")
 ```
 
+## Digital twin
+
+`cam_slicer.digital_twin` provides lightweight `DigitalTwin` and `WorkshopTwin`
+classes for deterministic simulation and monitoring. Processed toolpath points
+are stored in the module-level `preview_points` list and all operations are
+logged to `log.txt` for easy diagnostics.
+
 `cam_slicer.core.header_footer` provides controller-specific headers and
 footers, while `cam_slicer.core.gcode_export` handles G-code formatting.
 

--- a/cam_slicer/digital_twin.py
+++ b/cam_slicer/digital_twin.py
@@ -1,15 +1,168 @@
-validate_toolpath(
-            toolpath,
-            axis_range=axis_range or DEFAULT_AXIS_RANGE,
+"""Lightweight digital twin utilities with deterministic behaviour."""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Callable, Dict, Iterable, List, Tuple
+
+from .robotics.safety import validate_toolpath
+
+# configure module level logger writing to ``log.txt``
+_logger = logging.getLogger(__name__)
+_handler = logging.FileHandler("log.txt")
+_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+_logger.addHandler(_handler)
+_logger.setLevel(logging.INFO)
+_logger.propagate = False
+
+# shared buffer of processed preview points
+preview_points: List[Tuple[float, float, float]] = []
+
+
+class DigitalTwin:
+    """Simple state model of a single CNC machine."""
+
+    def __init__(self, name: str | None) -> None:
+        """Create a new twin with optional ``name``."""
+        self.name = name or "machine"
+        self.state: Dict[str, float] = {"x": 0.0, "y": 0.0, "z": 0.0, "feed": 0.0, "speed": 0.0}
+        self._listeners: List[Callable[[Dict[str, float]], None]] = []
+        _logger.info("DigitalTwin %s initialised", self.name)
+
+    # public API -----------------------------------------------------------
+    def add_listener(self, cb: Callable[[Dict[str, float]], None]) -> None:
+        """Register ``cb`` to be called on state updates."""
+        self._listeners.append(cb)
+
+    def get_live_state(self) -> Dict[str, float]:
+        """Return a copy of the current machine state."""
+        return dict(self.state)
+
+    def simulate_toolpath(
+        self,
+        toolpath: Iterable[Tuple[float, float, float]],
+        *,
+        interval: float = 0.0,
+        delay: bool = True,
+        axis_range: Dict[str, Tuple[float, float]] | None = None,
+        heightmap: object | None = None,
+        max_feedrate: float | None = None,
+        max_acceleration: float | None = None,
+    ) -> List[str]:
+        """Simulate ``toolpath`` and populate ``preview_points``.
+
+        Parameters
+        ----------
+        toolpath:
+            Iterable of XYZ tuples.
+        interval:
+            Sleep duration between points when ``delay`` is ``True``.
+        delay:
+            If ``False``, no sleeping occurs.
+        axis_range, max_feedrate, max_acceleration:
+            Forwarded to :func:`validate_toolpath`.
+        heightmap:
+            Optional object providing ``get_offset(x, y)``.
+
+        Returns
+        -------
+        list[str]
+            Validation warnings produced by :func:`validate_toolpath`.
+        """
+        points = list(toolpath)
+        warnings = validate_toolpath(
+            points,
+            axis_range=axis_range,
             max_feedrate=max_feedrate,
             max_acceleration=max_acceleration,
         )
-
-        preview_points = []
-        for p in toolpath:
-            x, y, z = p
-            if heightmap:
-                z += heightmap.get_offset(x, y)
-            preview_points.append((x, y, z))
+        preview_points.clear()
+        for x, y, z in points:
+            if heightmap is not None:
+                z += float(heightmap.get_offset(x, y))
+            self.state["x"], self.state["y"], self.state["z"] = float(x), float(y), float(z)
+            preview_points.append((self.state["x"], self.state["y"], self.state["z"]))
+            self._notify()
             if delay and interval > 0:
                 time.sleep(interval)
+        _logger.info("%s simulated %d points", self.name, len(preview_points))
+        return warnings
+
+    # internal helpers -----------------------------------------------------
+    def _notify(self) -> None:
+        for cb in self._listeners:
+            cb(self.get_live_state())
+
+
+class WorkshopTwin:
+    """Manage a group of :class:`DigitalTwin` instances."""
+
+    def __init__(self) -> None:
+        """Initialise empty workshop."""
+        self.twins: Dict[str, DigitalTwin] = {}
+        self._conns: Dict[str, object] = {}
+        self._threads: Dict[str, threading.Thread] = {}
+        self._stops: Dict[str, threading.Event] = {}
+        self._listeners: List[Callable[[str, Dict[str, float]], None]] = []
+        _logger.info("WorkshopTwin initialised")
+
+    def add_listener(self, cb: Callable[[str, Dict[str, float]], None]) -> None:
+        """Register callback for any machine update."""
+        self._listeners.append(cb)
+
+    def _forward(self, name: str, state: Dict[str, float]) -> None:
+        for cb in self._listeners:
+            cb(name, state)
+
+    def add_machine(self, name: str, connection: object | None) -> DigitalTwin:
+        """Add a machine with optional streaming ``connection``."""
+        twin = DigitalTwin(name)
+        self.twins[name] = twin
+        self._conns[name] = connection
+        twin.add_listener(lambda s, n=name: self._forward(n, s))
+        return twin
+
+    def start_all(self) -> None:
+        """Start threads reading from machine connections."""
+        for name, conn in self._conns.items():
+            if conn is None or name in self._threads:
+                continue
+            stop = threading.Event()
+            thread = threading.Thread(target=self._reader, args=(name, conn, stop), daemon=True)
+            self._threads[name] = thread
+            self._stops[name] = stop
+            thread.start()
+        _logger.info("WorkshopTwin threads started")
+
+    def _reader(self, name: str, conn: object, stop: threading.Event) -> None:
+        twin = self.twins[name]
+        while not stop.is_set():
+            line = conn.readline()
+            if not line:
+                continue
+            parts = line.strip().split()
+            for part in parts:
+                axis = part[0].lower()
+                try:
+                    val = float(part[1:])
+                except ValueError:
+                    continue
+                if axis in ("x", "y", "z"):
+                    twin.state[axis] = val
+            twin._notify()
+        _logger.info("Reader for %s stopped", name)
+
+    def stop_all(self) -> None:
+        """Stop all machine threads."""
+        for name, stop in list(self._stops.items()):
+            stop.set()
+        for name, thread in list(self._threads.items()):
+            thread.join(timeout=0.1)
+        self._threads.clear()
+        self._stops.clear()
+        _logger.info("WorkshopTwin threads stopped")
+
+    def get_states(self) -> Dict[str, Dict[str, float]]:
+        """Return live states for all machines."""
+        return {name: twin.get_live_state() for name, twin in self.twins.items()}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root on sys.path for direct test execution.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_digital_twin.py
+++ b/tests/test_digital_twin.py
@@ -1,7 +1,10 @@
+import pytest
+
+from cam_slicer.digital_twin import DigitalTwin, preview_points
+
+
 def test_simulate_toolpath_no_delay(monkeypatch):
     """No sleep should occur when delay is False."""
-    pytest.importorskip("matplotlib")
-
     called = []
 
     def fake_sleep(_):
@@ -10,7 +13,16 @@ def test_simulate_toolpath_no_delay(monkeypatch):
     import cam_slicer.digital_twin as dt
 
     monkeypatch.setattr(dt.time, "sleep", fake_sleep)
-    twin = dt.DigitalTwin(None)
+    twin = DigitalTwin(None)
     twin.simulate_toolpath([(0, 0, 0), (1, 0, 0)], interval=0.1, delay=False)
 
     assert not called
+
+
+def test_preview_points_buffering():
+    """Buffered points should be exposed via ``preview_points``."""
+    twin = DigitalTwin("demo")
+    preview_points.clear()
+    twin.simulate_toolpath([(0, 0, 0), (1, 1, 1)], interval=0, delay=False)
+    assert preview_points == [(0, 0, 0), (1, 1, 1)]
+    assert twin.get_live_state()["x"] == 1.0


### PR DESCRIPTION
## Summary
- rewrite digital_twin with deterministic DigitalTwin and WorkshopTwin classes
- record processed toolpath points in module-level `preview_points`
- add concise tests for buffering and workshop operation

## Testing
- `pytest tests/test_digital_twin.py tests/test_workshop_twin.py -q`
- `pytest tests/test_digital_twin.py tests/test_workshop_twin.py tests/test_imports.py tests/test_core_functions.py tests/test_safety.py tests/test_ros_bridge.py -q` *(fails: ImportError: cannot import name 'load_plugins' from 'cam_slicer'; NameError: Dict not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ef078c988333a25897cdb3885ede