### PR TITLE
feat: safe debris detection fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,10 +956,10 @@ from cam_slicer.ai.debris import (
     plan_toolpath_avoiding_debris,
 )
 
-remind = add_debris_zones_from_image("workspace.jpg", geo_fence)
+boxes = add_debris_zones_from_image("workspace.jpg", geo_fence)
 safe_path = plan_toolpath_avoiding_debris(toolpath, geo_fence)
-if remind:
-    print("Clean table reminder")
+if not boxes:
+    print("No debris detected or detection unavailable")
 ```
 Use the **Debris scan & avoid** button in the *Export & Streaming* panel of the UI to perform this check before running a job.
 

--- a/cam_slicer/ai/debris.py
+++ b/cam_slicer/ai/debris.py
@@ -12,14 +12,14 @@ logger = logging.getLogger(__name__)
 
 try:  # optional dependencies
     from ultralytics import YOLO
-except ModuleNotFoundError as exc:  # pragma: no cover - optional
-    logger.warning("ultralytics not installed: %s", exc)
+except Exception as exc:  # pragma: no cover - optional
+    logger.warning("ultralytics not available: %s", exc)
     YOLO = None  # type: ignore
 
 try:
     import cv2  # type: ignore
-except ModuleNotFoundError as exc:  # pragma: no cover - optional
-    logger.warning("opencv-python not installed: %s", exc)
+except Exception as exc:  # pragma: no cover - optional
+    logger.warning("opencv-python not available: %s", exc)
     cv2 = None  # type: ignore
 
 BoundingBox = Tuple[float, float, float, float]
@@ -45,3 +45,77 @@ def detect_debris(image_path: str) -> List[BoundingBox]:
 
     if image_path == "0":
         cap = cv2.VideoCapture(0)
+        success, frame = cap.read()
+        cap.release()
+        if not success:
+            logger.error("Failed to capture frame from webcam")
+            return []
+        image = frame
+    else:
+        image = str(image_path)
+
+    results = model(image)
+    boxes: List[BoundingBox] = []
+    for res in results:  # pragma: no cover - heavy computation
+        for x1, y1, x2, y2 in res.boxes.xyxy.tolist():
+            boxes.append((float(x1), float(y1), float(x2), float(y2)))
+    logger.info("Detected %d debris regions", len(boxes))
+    return boxes
+
+
+def add_debris_zones_from_image(image: str | Path, fence: GeoFence) -> List[BoundingBox]:
+    """Update ``fence`` with debris zones detected in ``image``.
+
+    The function relies on :func:`detect_debris` which in turn depends on
+    optional imaging libraries. When those libraries are missing the function
+    simply logs the issue and returns an empty list, allowing callers to proceed
+    without special handling.
+
+    Parameters
+    ----------
+    image : str or Path
+        Path to the image file to analyze. ``"0"`` activates a webcam capture.
+    fence : GeoFence
+        Geofence instance that will receive new forbidden zones.
+
+    Returns
+    -------
+    list of tuple
+        List of added bounding boxes. Empty if detection could not run.
+    """
+
+    logger.info("Scanning %s for debris", image)
+    try:
+        boxes = detect_debris(str(image))
+    except ImportError as exc:  # pragma: no cover - optional
+        logger.warning("Debris detection skipped: %s", exc)
+        return []
+
+    if not boxes:
+        logger.info("No debris found in %s", image)
+        return []
+
+    for x1, y1, x2, y2 in boxes:
+        fence.forbidden_zones.append((x1, y1, x2, y2))
+    logger.info("Added %d debris zones to geofence", len(boxes))
+    return boxes
+
+
+def plan_toolpath_avoiding_debris(
+    toolpath: Iterable[Tuple[float, float, float]],
+    fence: GeoFence,
+    safe_z: float = 5.0,
+) -> List[Tuple[float, float, float]]:
+    """Filter and adjust ``toolpath`` based on debris zones.
+
+    The toolpath is first filtered using :meth:`GeoFence.filter_toolpath` and
+    then raised to ``safe_z`` inside air-move zones via
+    :meth:`GeoFence.adjust_toolpath_for_air_moves`.
+    """
+
+    original = list(toolpath)
+    logger.info("Planning path with %d points", len(original))
+    filtered = fence.filter_toolpath(original)
+    adjusted = fence.adjust_toolpath_for_air_moves(filtered, safe_z=safe_z)
+    logger.info("Path reduced to %d points after debris avoidance", len(adjusted))
+    return adjusted

--- a/tests/test_debris.py
+++ b/tests/test_debris.py
@@ -3,17 +3,29 @@ from cam_slicer.utils import GeoFence
 
 
 def test_add_debris_zones(monkeypatch):
-    """Debris zones are added and reminder is triggered."""
-    monkeypatch.setattr('cam_slicer.ai.debris.detect_debris', lambda p: [(0,0,1,1), (2,2,3,3)])
+    """Detected zones are appended to the geofence."""
+    monkeypatch.setattr(
+        "cam_slicer.ai.debris.detect_debris", lambda p: [(0, 0, 1, 1), (2, 2, 3, 3)]
+    )
     fence = GeoFence()
-    remind = add_debris_zones_from_image('img.jpg', fence, reminder_threshold=1)
-    assert remind
+    boxes = add_debris_zones_from_image("img.jpg", fence)
+    assert boxes == [(0, 0, 1, 1), (2, 2, 3, 3)]
     assert fence.is_inside(0.5, 0.5)
 
 
 def test_plan_toolpath_avoiding_debris():
     """Toolpath filtered and raised over air-move zone."""
-    fence = GeoFence(forbidden_zones=[(0,0,1,1)], air_move_zones=[(2,0,3,1)])
+    fence = GeoFence(forbidden_zones=[(0, 0, 1, 1)], air_move_zones=[(2, 0, 3, 1)])
     tp = [(0.5, 0.5, -1), (2.5, 0.5, -1)]
     result = plan_toolpath_avoiding_debris(tp, fence, safe_z=5)
     assert result == [(2.5, 0.5, 5)]
+
+
+def test_add_debris_zones_missing_deps(monkeypatch):
+    """Return empty list when imaging libraries are missing."""
+    monkeypatch.setattr("cam_slicer.ai.debris.YOLO", None)
+    monkeypatch.setattr("cam_slicer.ai.debris.cv2", None)
+    fence = GeoFence()
+    boxes = add_debris_zones_from_image("img.jpg", fence)
+    assert boxes == []
+    assert fence.forbidden_zones == []


### PR DESCRIPTION
## Summary
- make debris scanning robust when imaging libraries are missing
- document and log debris zone detection steps
- cover fallback behavior with tests

## Testing
- `pytest tests/test_debris.py -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory; ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68a5a72740e083339d889fbe66dbe82c