### PR TITLE
Add Job dataclass to machine manager

### DIFF
--- a/cam_slicer/machines/__init__.py
+++ b/cam_slicer/machines/__init__.py
@@ -1,6 +1,6 @@
 """Machine management for running multiple jobs."""
 
-from .machine import Machine, Job
-from .machine_manager import MachineManager
+from .machine import Machine
+from .machine_manager import MachineManager, Job
 
 __all__ = ["Machine", "MachineManager", "Job"]

--- a/cam_slicer/machines/machine_manager.py
+++ b/cam_slicer/machines/machine_manager.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List
 from cam_slicer.machines.machine import Machine
@@ -10,6 +11,15 @@ except ImportError:
     _ROSBridge = None
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Job:
+    """Simple job representation with status tracking."""
+
+    id: str
+    toolpath: list[tuple[float, float, float]]
+    status: str = "pending"
 
 
 class MachineManager:
@@ -68,3 +78,6 @@ class MachineManager:
         ]}
         Path(path).write_text(json.dumps(data, indent=2))
         logger.info("Saved machine config to %s", path)
+
+
+__all__ = ["Job", "MachineManager"]

--- a/tests/test_job_dataclass.py
+++ b/tests/test_job_dataclass.py
@@ -1,0 +1,10 @@
+from cam_slicer.machines.machine_manager import Job
+
+
+def test_job_defaults():
+    """Job dataclass initializes with pending status."""
+    toolpath = [(0.0, 0.0, 0.0)]
+    job = Job(id="j1", toolpath=toolpath)
+    assert job.id == "j1"
+    assert job.toolpath == toolpath
+    assert job.status == "pending"


### PR DESCRIPTION
## Summary
- define simple Job dataclass with id, toolpath and default status
- expose Job through __all__ and package __init__
- add unit test verifying Job default status

## Testing
- `pytest tests/test_job_dataclass.py -q`
- `pytest tests/test_machine_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5b6f270948333b6a545b39695bfcb