### PR TITLE
Add HTTPX dependency and installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Full documentation: https://example.github.io/cam_slicer/
 
 Simple engine to generate headers and footers for CNC controllers and to modify toolpaths.
 
+## Installation
+
+Use a virtual environment and install required packages, including FastAPI and the HTTPX client used in tests:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
 ## Usage
 
 Create `ControllerConfig` with `CONTROLLER_TYPE` set to supported type (`grbl` or `smoothie`) and call `_get_header_footer()`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ uvicorn
 websockets
 PyYAML
 opencv-python
+httpx>=0.28


### PR DESCRIPTION
## Summary
- add `httpx>=0.28` to requirements for FastAPI client testing
- document virtualenv setup and dependency installation in README

## Testing
- `pytest tests/test_api_server.py` *(fails: skipped due to missing dependency httpx; attempted installation but repository proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c41c0a848333a06dbd68a7c84c77