### PR TITLE
feat: add camera REST API and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ After installation you can use:
 - `camslicer-mm` – manage multiple machines
 
 
+### Vision REST API
+
+The API server exposes simple camera control:
+
+- `GET /vision/cameras` – list available camera indices.
+- `GET /vision/camera/current` – show stored selection.
+- `POST /vision/camera/select` – validate and persist chosen index.
+
+Selection is saved to `~/.camslicer/camera.json` and reused by `scripts/vision_to_cnc.py`,
+which prefers `--cam` argument over the config file and falls back to index `0`.
+
+
 Create `ControllerConfig` with `CONTROLLER_TYPE` set to supported type (`grbl` or `smoothie`) and call `_get_header_footer()`.
 Toolpaths can be processed with `process_toolpath()` using different cutting strategies.
 

--- a/cam_slicer/api_server.py
+++ b/cam_slicer/api_server.py
@@ -33,6 +33,7 @@ from cam_slicer.ai.analyzers import (
 from cam_slicer.sender import list_available_ports
 from cam_slicer.probing import probe_heightmap
 from cam_slicer.heightmap import HeightMap, apply_heightmap_to_gcode
+from cam_slicer.vision.camera_router import router as vision_router
 
 app = FastAPI(title="CAM Slicer API")
 
@@ -61,6 +62,8 @@ def create_app() -> FastAPI:
         logs_dir = Path("logs")
         logs_dir.mkdir(exist_ok=True)
         app.mount("/logs", StaticFiles(directory=str(logs_dir)), name="logs")
+    if not any(getattr(r, "path", "") == "/vision/cameras" for r in app.routes):
+        app.include_router(vision_router)
 
     return app
 

--- a/cam_slicer/vision/__init__.py
+++ b/cam_slicer/vision/__init__.py
@@ -1,12 +1,17 @@
 """Camera-based detection utilities."""
 
-from .debris_detector import detect_objects, run_live_detection
-from .board_detector import (
-    detect_board_position,
-    get_transform_from_detection,
-    auto_transform_gcode,
-    process_camera_to_gcode,
-)
+try:  # optional dependencies may be missing (e.g., cv2, ultralytics)
+    from .debris_detector import detect_objects, run_live_detection
+    from .board_detector import (
+        detect_board_position,
+        get_transform_from_detection,
+        auto_transform_gcode,
+        process_camera_to_gcode,
+    )
+except Exception:  # pragma: no cover - optional
+    detect_objects = run_live_detection = None
+    detect_board_position = get_transform_from_detection = None
+    auto_transform_gcode = process_camera_to_gcode = None
 
 __all__ = [
     "detect_objects",

--- a/cam_slicer/vision/camera_config.py
+++ b/cam_slicer/vision/camera_config.py
@@ -1,0 +1,40 @@
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Dict
+
+CONFIG_PATH = Path(os.path.expanduser("~/.camslicer/camera.json"))
+logger = logging.getLogger(__name__)
+
+def ensure_dir() -> None:
+    """Vytvor adresár pre config ak neexistuje."""
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+def load_config() -> Dict[str, int]:
+    """Načíta config JSON, ak chýba vráti prázdny slovník."""
+    try:
+        data = CONFIG_PATH.read_text(encoding="utf-8")
+        return json.loads(data)
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:  # pragma: no cover
+        logger.warning("Neplatný config: %s", exc)
+        return {}
+
+def save_config(cfg: Dict[str, int]) -> None:
+    """Uloží config atomicky."""
+    ensure_dir()
+    tmp = CONFIG_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps(cfg), encoding="utf-8")
+    tmp.replace(CONFIG_PATH)
+    logger.info("Config uložený do %s", CONFIG_PATH)
+
+def get_current_index(default: int = 0) -> int:
+    """Vráti zvolený index kamery alebo default."""
+    cfg = load_config()
+    return int(cfg.get("index", default))
+
+def set_current_index(idx: int) -> None:
+    """Uloží aktuálny index kamery."""
+    save_config({"index": int(idx)})

--- a/cam_slicer/vision/camera_router.py
+++ b/cam_slicer/vision/camera_router.py
@@ -1,0 +1,80 @@
+import logging
+import time
+from typing import List
+
+try:  # pragma: no cover - cv2 may be missing
+    import cv2  # type: ignore
+except Exception:  # pragma: no cover
+    cv2 = None  # type: ignore
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from . import camera_config as cc
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+MAX_INDEX = 10
+TIMEOUT = 0.5
+
+
+def try_open(index: int) -> bool:
+    """Skúsi otvoriť kameru a načítať jeden frame."""
+    if cv2 is None:
+        return False
+    cap = cv2.VideoCapture(index)
+    if not cap.isOpened():
+        cap.release()
+        return False
+    start = time.time()
+    ok = False
+    while time.time() - start < TIMEOUT:
+        ok, _ = cap.read()
+        if ok:
+            break
+    cap.release()
+    return bool(ok)
+
+
+class CameraInfo(BaseModel):
+    index: int
+    ok: bool
+
+
+class CamerasResponse(BaseModel):
+    available: List[CameraInfo]
+    default: int
+
+
+class CameraIndex(BaseModel):
+    index: int
+
+
+class CameraSelectResponse(BaseModel):
+    index: int
+    message: str
+
+
+@router.get("/vision/cameras", response_model=CamerasResponse)
+def list_cameras() -> CamerasResponse:
+    """Vracia zoznam dostupných kamier."""
+    cams = [CameraInfo(index=i, ok=try_open(i)) for i in range(MAX_INDEX + 1)]
+    return CamerasResponse(available=cams, default=cc.get_current_index())
+
+
+@router.get("/vision/camera/current", response_model=CameraIndex)
+def current_camera() -> CameraIndex:
+    """Vráti aktuálny index kamery."""
+    return CameraIndex(index=cc.get_current_index())
+
+
+@router.post("/vision/camera/select", response_model=CameraSelectResponse)
+def select_camera(req: CameraIndex) -> CameraSelectResponse:
+    """Uloží zvolenú kameru po validácii."""
+    if not 0 <= req.index <= MAX_INDEX:
+        raise HTTPException(status_code=400, detail="Neplatný index")
+    if not try_open(req.index):
+        raise HTTPException(status_code=400, detail="Kameru sa nepodarilo otvoriť")
+    cc.set_current_index(req.index)
+    logger.info("Zvolená kamera %d uložená", req.index)
+    return CameraSelectResponse(index=req.index, message="Kamera nastavená")

--- a/scripts/vision_to_cnc.py
+++ b/scripts/vision_to_cnc.py
@@ -1,7 +1,79 @@
 """Compatibility wrapper for the old vision_to_cnc script."""
-from cam_slicer.vision_bridge import M_affine, main, px_to_xy, write_move_gcode
 
-__all__ = ["M_affine", "main", "px_to_xy", "write_move_gcode"]
+import argparse
+import logging
+
+try:  # pragma: no cover - cv2 may be missing on CI
+    import cv2  # type: ignore
+except Exception:  # pragma: no cover
+    cv2 = None  # type: ignore
+
+import cam_slicer.vision_bridge as _vb
+from cam_slicer.vision import camera_config as cc
+
+M_affine = _vb.M_affine
+
+
+def px_to_xy(px):
+    _vb.M_affine = M_affine
+    return _vb.px_to_xy(px)
+
+
+def write_move_gcode(x, y, path="move_to_target.gcode"):
+    _vb.M_affine = M_affine
+    return _vb.write_move_gcode(x, y, path=path)
+
+
+run_main = _vb.main
+
+__all__ = ["M_affine", "px_to_xy", "write_move_gcode"]
+
+LOG_PATH = "logs/log.txt"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    handlers=[logging.FileHandler(LOG_PATH), logging.StreamHandler()],
+)
+logger = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parsuje CLI argumenty."""
+    p = argparse.ArgumentParser(description="Vision->CNC helper")
+    p.add_argument("--cam", type=int, default=None, help="Index kamery")
+    return p.parse_args()
+
+
+def select_index(args: argparse.Namespace) -> int:
+    """Zvolí index kamery: CLI > config > 0."""
+    idx = args.cam if args.cam is not None else cc.get_current_index(default=0)
+    logger.info("Používam kameru index=%d (CLI má prednosť pred configom)", idx)
+    return idx
+
+
+def open_camera(idx: int) -> "cv2.VideoCapture":
+    """Otvára kameru a overí dostupnosť."""
+    if cv2 is None:
+        logger.error("OpenCV nie je dostupné")
+        raise SystemExit(1)
+    cap = cv2.VideoCapture(idx)
+    if not cap.isOpened():
+        logger.error("Kameru %d sa nepodarilo otvoriť", idx)
+        raise SystemExit(1)
+    cc.set_current_index(idx)
+    return cap
+
+
+def main() -> None:
+    """Spustí interaktívny proces."""
+    args = parse_args()
+    idx = select_index(args)
+    cap = open_camera(idx)
+    cap.release()
+    _vb.M_affine = M_affine
+    run_main()
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_camera_config.py
+++ b/tests/test_camera_config.py
@@ -1,0 +1,13 @@
+import json
+
+from cam_slicer.vision import camera_config as cc
+
+
+def test_set_get_current_index(tmp_path, monkeypatch):
+    cfg = tmp_path / "camera.json"
+    monkeypatch.setattr(cc, "CONFIG_PATH", cfg)
+    cc.set_current_index(2)
+    assert cc.get_current_index() == 2
+    cc.set_current_index(5)
+    data = json.loads(cfg.read_text())
+    assert data["index"] == 5

--- a/tests/test_camera_router.py
+++ b/tests/test_camera_router.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+
+from cam_slicer.api_server import create_app
+from cam_slicer.vision import camera_router, camera_config as cc
+
+
+class DummyCap:
+    def __init__(self, idx: int) -> None:
+        self.idx = idx
+
+    def isOpened(self) -> bool:
+        return self.idx == 1
+
+    def read(self):
+        return (self.idx == 1, None)
+
+    def release(self) -> None:
+        pass
+
+
+class DummyCV2:
+    def VideoCapture(self, idx: int) -> DummyCap:  # type: ignore
+        return DummyCap(idx)
+
+
+def test_camera_endpoints(monkeypatch, tmp_path):
+    monkeypatch.setattr(camera_router, "cv2", DummyCV2())
+    monkeypatch.setattr(cc, "CONFIG_PATH", tmp_path / "camera.json")
+    client = TestClient(create_app())
+
+    resp = client.get("/vision/cameras")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["available"]) == 11
+
+    resp = client.post("/vision/camera/select", json={"index": 1})
+    assert resp.status_code == 200
+    assert cc.get_current_index() == 1
+
+    resp = client.get("/vision/camera/current")
+    assert resp.json()["index"] == 1
+
+    resp = client.post("/vision/camera/select", json={"index": 2})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- add camera_config module with atomic JSON persistence
- expose /vision camera selection endpoints via FastAPI router
- use camera index from CLI or config in vision_to_cnc script
- document camera REST API

## Testing
- `pytest tests/test_camera_config.py tests/test_camera_router.py tests/test_vision_to_cnc.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b21260d20483338bd09a569bc0df9d